### PR TITLE
NSA-2021 - format search criteria to match formatting when storing

### DIFF
--- a/src/app/indexes/UserIndex.js
+++ b/src/app/indexes/UserIndex.js
@@ -372,7 +372,8 @@ class UserIndex extends Index {
   }
 
   async search(criteria, page = 1, pageSize = 25, sortBy = 'searchableName', sortAsc = true, filters = undefined) {
-    const pageOfDocuments = await super.search(criteria, page, pageSize, sortBy, sortAsc, filters);
+    const searchableCriteria = getSearchableString(criteria);
+    const pageOfDocuments = await super.search(searchableCriteria, page, pageSize, sortBy, sortAsc, filters);
     const users = pageOfDocuments.documents.map(document => ({
       id: document.id,
       firstName: document.firstName,


### PR DESCRIPTION
Otherwise cannot search on email for example as will be stored as `some__dot__thing__at__somewhere` but search will be for `some.thing@somewhere`