### PR TITLE
NSA-2175 Partial Email Search For User

### DIFF
--- a/src/app/indexes/utils.js
+++ b/src/app/indexes/utils.js
@@ -1,8 +1,8 @@
 const getSearchableString = (source) => {
   return source.toLowerCase()
     .replace(/\s/g, '')
-    .replace(/@/g, '__at__')
-    .replace(/\./g, '__dot__');
+    .replace(/@/g, '__at__+')
+    .replace(/\./g, '__dot__+');
 };
 
 module.exports = {


### PR DESCRIPTION
The current logic places a wildcard at the end of the search term. For example com* will search for documents that have a term that starts with com, ignoring case. So if you need another term like dot to be included then need to use __dot__+com* or %2e+com*