### PR TITLE
PR-NSA-4630-INT-Re-index-devices 

### DIFF
--- a/src/app/indexes/DeviceIndex.js
+++ b/src/app/indexes/DeviceIndex.js
@@ -181,7 +181,7 @@ class DeviceIndex extends Index {
         assigneeId: device.user ? device.user.sub : '',
         assignee,
         organisationName,
-        lastLogin: device.loginStats ? device.loginStats.lastLogin.getTime() : 0,
+        lastLogin: device.loginStats && device.loginStats.lastLogin ? device.loginStats.lastLogin.getTime() : 0,
         numberOfSuccessfulLoginsInPast12Months: device.loginStats ? device.loginStats.loginsInPast12Months.length : 0,
       };
     });

--- a/test/scheduledTasks/updateAuditCache.test.js
+++ b/test/scheduledTasks/updateAuditCache.test.js
@@ -41,14 +41,23 @@ const batchOfAuditRecords = [
     userId: 'user-2',
   },
 ];
+
+const getPreviousDate = (month) => {
+  const d = new Date()
+  return new Date(d.setMonth(d.getMonth() - month))
+}
+
+const lastLogin = getPreviousDate(6)
+const lastLoginAfterThreeMonths = getPreviousDate(3)
+
 const loginStats = [
   {
     userId: 'user-1',
     stats: {
-      lastLogin: new Date(Date.UTC(2019, 9, 2, 10, 45, 12)),
+      lastLogin: lastLogin,
       lastStatusChange: undefined,
       loginsInPast12Months: [
-        new Date(Date.UTC(2019, 11, 2, 10, 45, 12)),
+        lastLoginAfterThreeMonths
       ],
     },
   },
@@ -114,7 +123,7 @@ describe('when updating audit cache with stats', () => {
     expect(setLoginStatsForUser).toHaveBeenCalledTimes(2);
     expect(setLoginStatsForUser.mock.calls[0][0]).toBe('user-1');
     expect(setLoginStatsForUser.mock.calls[0][1]).toMatchObject({
-      lastLogin: new Date(Date.UTC(2019, 9, 2, 10, 45, 12)),
+      lastLogin: lastLogin
     });
     expect(setLoginStatsForUser.mock.calls[1][0]).toBe('user-2');
     expect(setLoginStatsForUser.mock.calls[1][1]).toMatchObject({
@@ -132,7 +141,7 @@ describe('when updating audit cache with stats', () => {
     expect(setLoginStatsForUser.mock.calls[0][0]).toBe('user-1');
     expect(setLoginStatsForUser.mock.calls[0][1]).toMatchObject({
       loginsInPast12Months: [
-        new Date(Date.UTC(2019, 11, 2, 10, 45, 12))
+        lastLoginAfterThreeMonths
       ],
     });
     expect(setLoginStatsForUser.mock.calls[1][0]).toBe('user-2');


### PR DESCRIPTION
Ticket is 4630, But **ticket number in the branch name is wrong**.

LastLogin Object was null from device.loginStats.
So null has been checked to avoid exception.

Tried to replicate the issue in the DEV environment by adding some device records in to the table.
But due to insufficient/mismatch data, no device returned.

But the current fix will solve the exception. 