### PR TITLE
[DSI-6605] - Remove devices API dependency checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "login.dfe.dao": "^4.0.0",
         "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
         "login.dfe.express-flash-2": "git+https://github.com/DFE-Digital/login.dfe.express-flash-2.git#v2.0.0",
-        "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.0",
+        "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.1",
         "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
         "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",
@@ -8950,8 +8950,8 @@
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-flash-2.git#4bcdae829a65fc3ccfa34130973a40cc3ee4eb08"
     },
     "node_modules/login.dfe.healthcheck": {
-      "version": "4.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.healthcheck.git#b9f33ed33c9c2ab9ae48ebb68438126def371a87",
+      "version": "4.0.1",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.healthcheck.git#3cd74cff46324a5c36189c5efde5709c8373b5ed",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "login.dfe.dao": "^4.0.0",
     "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
     "login.dfe.express-flash-2": "git+https://github.com/DFE-Digital/login.dfe.express-flash-2.git#v2.0.0",
-    "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.0",
+    "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.1",
     "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
     "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",


### PR DESCRIPTION
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-6605

**Changes:**
Bumped `login.dfe.healthcheck` version to remove the health checks performed for the `Devices API` in PROD env. 

**Healtcheck docs**
https://dfe-secureaccess.atlassian.net/wiki/spaces/NSA/pages/3669426177/Healhtcheck+library