### PR TITLE
[NSA-7677] User indexer changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,12 @@
     "strict": "off",
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "max-len": 0
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
+  "env": {
+    "node": true,
+    "jest": true
   }
 }

--- a/src/app/indexes/Index.js
+++ b/src/app/indexes/Index.js
@@ -1,8 +1,9 @@
 const chunk = require('lodash/chunk');
-const logger = require('./../../infrastructure/logger');
-const { listIndexes, createIndex, storeDocumentsInIndex, searchIndex, deleteIndex, deleteDocumentInIndex } = require('./../../infrastructure/search');
-const cache = require('./../../infrastructure/cache');
-const { forEachAsync } = require('./../../utils/async');
+const logger = require('../../infrastructure/logger');
+const {
+  listIndexes, createIndex, storeDocumentsInIndex, searchIndex, deleteIndex, deleteDocumentInIndex,
+} = require('../../infrastructure/search');
+const { forEachAsync } = require('../../utils/async');
 
 const ensureValueValidForField = (value, field) => {
   if (!value && field.key) {
@@ -11,12 +12,16 @@ const ensureValueValidForField = (value, field) => {
   if (!value && field.type === 'Collection') {
     throw new Error(`document does not have a value for field ${field.name}. Collection fields must have a value`);
   }
-  if (field.type === 'Int64' && value && isNaN(parseInt(value))) {
+  if (field.type === 'Int64' && value && Number.isNaN(parseInt(value, 10))) {
     throw new Error(`document has value ${value} for Int64 field ${field.name}, which is not a valid Int64`);
   }
+  if (field.type === 'DateTimeOffset' && value && !(value instanceof Date)) {
+    throw new Error(`document has value ${value} for DateTimeOffset field ${field.name}, which is not a valid date`);
+  }
 };
+
 const ensureDocumentsAreValidStructure = (documents, structure) => {
-  const fields = Object.keys(structure).map(fieldName => ({
+  const fields = Object.keys(structure).map((fieldName) => ({
     name: fieldName,
     type: structure[fieldName].type,
     key: structure[fieldName].key,
@@ -32,8 +37,45 @@ const ensureDocumentsAreValidStructure = (documents, structure) => {
       } catch (e) {
         throw new Error(`${e.message} (document: ${JSON.stringify(document)})`);
       }
-    })
+    });
   });
+};
+
+const attemptToStoreDocuments = async (name, keyFieldName, documents, attempts = 3) => {
+  if (attempts > 0 && documents.length > 0) {
+    const response = await storeDocumentsInIndex(name, documents);
+
+    // Response code 207 indicates there were some failures in the request, some of which can be retried.
+    // https://learn.microsoft.com/en-us/rest/api/searchservice/addupdate-or-delete-documents#response
+    if (response.statusCode === 207) {
+      const responseDocuments = response.body.value ?? [];
+      const failedDocuments = responseDocuments.filter((doc) => doc.status === false);
+      const canRetry = (document) => [409, 422, 503].includes(document.statusCode);
+
+      const errorDocuments = failedDocuments.filter((doc) => !canRetry(doc));
+      if (errorDocuments.length > 1) {
+        const statusCodes = [...new Set(errorDocuments.map((doc) => doc.statusCode))].join();
+        logger.error(`Documents failed to index into "${name}", status code(s): ${statusCodes}`, {
+          documents: errorDocuments,
+        });
+      }
+
+      const responseRetryDocuments = failedDocuments.filter((doc) => canRetry(doc));
+      const retryKeys = responseRetryDocuments.map((doc) => doc.key);
+      if (retryKeys.length > 1) {
+        if (attempts === 1) {
+          const statusCodes = [...new Set(responseRetryDocuments.map((doc) => doc.statusCode))].join();
+          logger.error(`Documents failed to index into "${name}" after multiple retries, status code(s): ${statusCodes}`, {
+            documents: responseRetryDocuments,
+          });
+        } else {
+          await new Promise((resolve) => { setTimeout(resolve, 500); });
+        }
+        const retryDocuments = documents.filter((doc) => retryKeys.includes(doc[keyFieldName]));
+        await attemptToStoreDocuments(name, keyFieldName, retryDocuments, attempts - 1);
+      }
+    }
+  }
 };
 
 class Index {
@@ -50,11 +92,21 @@ class Index {
     await forEachAsync(batches, async (batch, index) => {
       logger.debug(`Writing batch ${index + 1} of ${batches.length} to ${this.name}`, { correlationId });
       try {
-        await storeDocumentsInIndex(this.name, batch);
+        const keyField = Object.entries(this.structure).find(([, value]) => value.key === true);
+        if (typeof keyField === 'undefined') {
+          throw new Error(`No field set as the key for Index ${this.name}`);
+        }
+
+        const keyFieldName = keyField[0];
+        await attemptToStoreDocuments(
+          this.name,
+          keyFieldName,
+          batch.map((x) => ({ ...x, '@search.action': 'upload' })),
+        );
       } catch (e) {
         throw new Error(`Error writing batch ${index} to ${this.name} - ${e.message}`);
       }
-    })
+    });
   }
 
   async search(criteria, page, pageSize, sortBy, sortAsc = true, filters = undefined, searchFields = undefined) {
@@ -79,9 +131,9 @@ class Index {
             fieldType: field.type,
             values: filter.values,
           });
-        })
+        });
       }
-      return await searchIndex(this.name, criteria, page, pageSize, sortBy, sortAsc, mappedFilters, searchFields)
+      return await searchIndex(this.name, criteria, page, pageSize, sortBy, sortAsc, mappedFilters, searchFields);
     } catch (e) {
       throw new Error(`Error searching ${this.name} using criteria '${criteria}' (page=${page}, pageSize=${pageSize}, sortBy=${sortBy}, sortAsc=${sortAsc}, filters=${JSON.stringify(filters)}) - ${e.message}`);
     }
@@ -91,7 +143,7 @@ class Index {
     try {
       await deleteDocumentInIndex(this.name, id);
     } catch (e) {
-      throw new Error(`Error deleting document with id ${id} from index ${this.name} - ${e.message}`)
+      throw new Error(`Error deleting document with id ${id} from index ${this.name} - ${e.message}`);
     }
   }
 

--- a/src/app/indexes/UserIndex.js
+++ b/src/app/indexes/UserIndex.js
@@ -191,7 +191,7 @@ const updateUsersWithOrganisations = async (users, correlationId) => {
   console.debug('All user organisations read. Mapping details to user...');
   for (let i = 0; i < users.length; i += 1) {
     user = users[i];
-    console.debug(`Mapping org details for user ${i + 1} of ${users.length} (${user.email} / ${user.id})`, { correlationId });
+    console.debug(`Mapping org details for user ${i + 1} of ${users.length} (${user.id})`, { correlationId });
 
     user.primaryOrganisation = user.organisationMappings.length > 0 ? user.organisationMappings[0].organisation.name : undefined;
     user.organisations = user.organisationMappings.map(x => x.organisation.id);

--- a/src/infrastructure/logger/index.js
+++ b/src/infrastructure/logger/index.js
@@ -1,12 +1,10 @@
 'use strict';
 
-/* eslint-disable no-unused-expressions */
-
 const winston = require('winston');
-const config = require('../config');
 const appInsights = require('applicationinsights');
 const AuditTransporter = require('login.dfe.audit.transporter');
 const AppInsightsTransport = require('login.dfe.winston-appinsights');
+const config = require('../config');
 
 const logLevel = (config && config.loggerSettings && config.loggerSettings.logLevel) ? config.loggerSettings.logLevel : 'info';
 
@@ -28,12 +26,18 @@ const customLevels = {
   },
 };
 
+// Formatter to hide audit records from other loggers.
+const hideAudit = winston.format((info) => ((info.level.toLowerCase() === 'audit') ? false : info));
+
 const loggerConfig = {
   levels: customLevels.levels,
   transports: [],
 };
 
-loggerConfig.transports.push(new (winston.transports.Console)({ level: logLevel, colorize: true }));
+loggerConfig.transports.push(new (winston.transports.Console)({
+  format: winston.format.combine(hideAudit(), winston.format.simple()),
+  level: logLevel,
+}));
 
 const opts = { application: config.loggerSettings.applicationName, level: 'audit' };
 const auditTransport = AuditTransporter(opts);
@@ -45,6 +49,7 @@ if (auditTransport) {
 if (config.hostingEnvironment.applicationInsights) {
   appInsights.setup(config.hostingEnvironment.applicationInsights).setAutoCollectConsole(false, false).start();
   loggerConfig.transports.push(new AppInsightsTransport({
+    format: winston.format.combine(hideAudit(), winston.format.json()),
     client: appInsights.defaultClient,
     applicationName: config.loggerSettings.applicationName || 'Search',
     type: 'event',

--- a/test/indexes/Index.store.test.js
+++ b/test/indexes/Index.store.test.js
@@ -1,0 +1,262 @@
+// eslint-disable-next-line global-require
+jest.mock('../../src/infrastructure/logger', () => require('../helpers').mockLogger());
+jest.mock('../../src/infrastructure/search', () => ({
+  storeDocumentsInIndex: jest.fn(),
+}));
+
+const { storeDocumentsInIndex } = require('../../src/infrastructure/search');
+const logger = require('../../src/infrastructure/logger');
+const Index = require('../../src/app/indexes/Index');
+
+let indexName;
+let indexStructure;
+let rawDocuments;
+let preparedDocuments;
+
+describe('Search Index store function', () => {
+  beforeEach(() => {
+    indexName = 'TESTING';
+    indexStructure = {
+      id: {
+        type: 'String',
+        key: true,
+        filterable: true,
+      },
+      firstName: {
+        type: 'String',
+      },
+      lastName: {
+        type: 'String',
+      },
+      email: {
+        type: 'String',
+      },
+    };
+
+    rawDocuments = [
+      {
+        id: 'doc-1',
+        firstName: 'document',
+        lastName: 'one',
+        email: 'doc-1@test.com',
+      },
+      {
+        id: 'doc-2',
+        firstName: 'document',
+        lastName: 'two',
+        email: 'doc-2@test.com',
+      },
+      {
+        id: 'doc-3',
+        firstName: 'document',
+        lastName: 'three',
+        email: 'doc-3@test.com',
+      },
+      {
+        id: 'doc-4',
+        firstName: 'document',
+        lastName: 'four',
+        email: 'doc-4@test.com',
+      },
+    ];
+    preparedDocuments = rawDocuments.map((doc) => ({ ...doc, '@search.action': 'upload' }));
+
+    logger.mockResetAll();
+
+    storeDocumentsInIndex.mockReset().mockReturnValue({
+      statusCode: 200,
+      body: {
+        value: rawDocuments.map((doc) => ({
+          key: doc.id,
+          status: true,
+          errorMessage: null,
+          statusCode: 200,
+        })),
+      },
+    });
+  });
+
+  it('Will throw an error if no field in the structure is specified as the key', async () => {
+    const index = new Index(indexName, {
+      id: {
+        type: 'String',
+        key: false,
+        filterable: true,
+      },
+    });
+    await expect(index.store(rawDocuments, 'testing')).rejects.toThrow(`No field set as the key for Index ${indexName}`);
+  });
+
+  it('Will attempt to store the documents if a field is specified as the key', async () => {
+    const index = new Index(indexName, indexStructure);
+    await expect(index.store(rawDocuments, 'testing')).resolves.not.toThrow();
+    expect(storeDocumentsInIndex).toHaveBeenCalledWith(indexName, preparedDocuments);
+  });
+
+  it("Will not attempt to retry storing documents, if the response code isn't 207", async () => {
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('Will not attempt to retry storing documents, if the response code is 207 and none of them can be retried', async () => {
+    storeDocumentsInIndex.mockReturnValue({
+      statusCode: 207,
+      body: {
+        value: rawDocuments.map((doc) => ({
+          key: doc.id,
+          status: false,
+          errorMessage: '400 Test',
+          statusCode: 400,
+        })),
+      },
+    });
+
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('Will log the response documents, if the response code is 207 and none of them can be retried', async () => {
+    const errorStatus = 400;
+    const responseDocuments = rawDocuments.map((doc) => ({
+      key: doc.id,
+      status: false,
+      errorMessage: '400 Log test',
+      statusCode: errorStatus,
+    }));
+
+    storeDocumentsInIndex.mockReturnValue({
+      statusCode: 207,
+      body: {
+        value: responseDocuments,
+      },
+    });
+
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(`Documents failed to index into "${indexName}", status code(s): ${errorStatus}`, {
+      documents: responseDocuments,
+    });
+  });
+
+  it('Will attempt to retry storing documents, if the response code is 207 and all of them can be retried (3 attempts default)', async () => {
+    const responseDocuments = rawDocuments.map((doc) => ({
+      key: doc.id,
+      status: false,
+      errorMessage: 'Clash testing',
+      statusCode: 409,
+    }));
+
+    storeDocumentsInIndex.mockReturnValue({
+      statusCode: 207,
+      body: {
+        value: responseDocuments,
+      },
+    });
+
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(3);
+    expect(storeDocumentsInIndex.mock.calls[0][1].length).toStrictEqual(rawDocuments.length);
+    expect(storeDocumentsInIndex.mock.calls[1][1].length).toStrictEqual(rawDocuments.length);
+    expect(storeDocumentsInIndex.mock.calls[2][1].length).toStrictEqual(rawDocuments.length);
+  });
+
+  it('Will attempt to retry storing documents that can be retried, if the response code is 207 and some of them fail on retries', async () => {
+    const errorStatus = 400;
+    const retryStatus = 409;
+    const firstResponseDocuments = rawDocuments.map((doc, index) => ({
+      key: doc.id,
+      status: false,
+      errorMessage: (index === 0) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 0) ? errorStatus : retryStatus,
+    }));
+    const secondResponseDocuments = firstResponseDocuments.map((doc, index) => ({
+      key: doc.key,
+      status: false,
+      errorMessage: (index === 1) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 1) ? errorStatus : retryStatus,
+    }));
+    const thirdResponseDocuments = secondResponseDocuments.map((doc, index) => ({
+      key: doc.key,
+      status: false,
+      errorMessage: (index === 2) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 2) ? errorStatus : retryStatus,
+    }));
+
+    storeDocumentsInIndex.mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: firstResponseDocuments,
+      },
+    }).mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: secondResponseDocuments,
+      },
+    }).mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: thirdResponseDocuments,
+      },
+    });
+
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(3);
+    expect(storeDocumentsInIndex.mock.calls[0][1].length).toStrictEqual(rawDocuments.length);
+    expect(storeDocumentsInIndex.mock.calls[1][1].length).toStrictEqual(rawDocuments.length - 1);
+    expect(storeDocumentsInIndex.mock.calls[2][1].length).toStrictEqual(rawDocuments.length - 2);
+  });
+
+  it('Will log any response documents that need to be retried, if they are not indexed after the attempt limit (3 attempts default)', async () => {
+    const errorStatus = 400;
+    const retryStatus = 409;
+    const firstResponseDocuments = rawDocuments.map((doc, index) => ({
+      key: doc.id,
+      status: false,
+      errorMessage: (index === 0) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 0) ? errorStatus : retryStatus,
+    }));
+    const secondResponseDocuments = firstResponseDocuments.map((doc, index) => ({
+      key: doc.key,
+      status: false,
+      errorMessage: (index === 1) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 1) ? errorStatus : retryStatus,
+    }));
+    const thirdResponseDocuments = secondResponseDocuments.map((doc, index) => ({
+      key: doc.key,
+      status: false,
+      errorMessage: (index === 2) ? 'Retry testing failure' : 'Retry testing',
+      statusCode: (index === 2) ? errorStatus : retryStatus,
+    }));
+
+    storeDocumentsInIndex.mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: firstResponseDocuments,
+      },
+    }).mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: secondResponseDocuments,
+      },
+    }).mockReturnValueOnce({
+      statusCode: 207,
+      body: {
+        value: thirdResponseDocuments,
+      },
+    });
+
+    const index = new Index(indexName, indexStructure);
+    await index.store(rawDocuments, 'testing');
+    expect(storeDocumentsInIndex).toHaveBeenCalledTimes(3);
+    expect(logger.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenLastCalledWith(`Documents failed to index into "${indexName}" after multiple retries, status code(s): ${retryStatus}`, {
+      documents: thirdResponseDocuments.filter((doc) => doc.statusCode !== 400),
+    });
+  });
+});


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7677

Changes:
- Update the UserIndex class to only return the 'users' index, generated by the data factory and new pipeline.
- Update the lastLogin data type to use `DateTimeOffset` and add validation for the date in the document validation to match the new index.
- Add retry logic to storing the documents in an index if the returned documents have status codes that can be retried (Unit tests created as well).
  - On first request, if 207 is returned (as described in the Azure Search documentation), the request are filtered to those which can be retried, and those which have errors.
  - Any error requests are logged with the user ID and the failure reason(s), and any request that can be retried are retried after 500ms.
  - This process then occurs again, and if any requests still need to be retried on the 3rd attempt, they are logged with the user ID and failure reason(s).
- ESLint corrections.