### PR TITLE
[HOTFIX for NSA-7677] Updated filter conversion logic when filtering on last login.

### DIFF
--- a/src/infrastructure/search/azureSearch.js
+++ b/src/infrastructure/search/azureSearch.js
@@ -124,9 +124,9 @@ const searchIndex = async (name, criteria, page, pageSize, sortBy, sortAsc = tru
       }
       if (filter.fieldType === 'Collection') {
         filterParam += `${filter.field}/any(x: search.in(x, '${filter.values.join(',')}', ','))`;
-      } else if (filter.fieldType === 'Int64' && filter.field !== 'lastLogin') {
+      } else if (filter.fieldType === 'Int64') {
         filterParam += `(${filter.field} eq ${filter.values.join(` or ${filter.field} eq `)})`;
-      } else if (filter.fieldType === 'Int64' && filter.field === 'lastLogin') {
+      } else if (filter.field === 'lastLogin') {
         const lastLoginFilterUrl = createLastLoginFilterExpression(filter);
         filterParam += `(${lastLoginFilterUrl})`;
       } else {

--- a/src/utils/userSearchHelpers.js
+++ b/src/utils/userSearchHelpers.js
@@ -1,11 +1,11 @@
 function createLastLoginFilterExpression(filter) {
   const dateFilterExpressions = filter.values.map((dateValue) => {
     if (dateValue === '0') {
-      return `${filter.field} eq ${dateValue}`;
+      return `${filter.field} eq null`;
     } if (dateValue === '1') {
-      return `${filter.field} ne 0`;
+      return `${filter.field} ne null`;
     }
-    return `${filter.field} ge ${dateValue}`;
+    return `${filter.field} ge ${new Date(Number.parseInt(dateValue, 10)).toISOString()}`;
   });
 
   return dateFilterExpressions.join(' or ');


### PR DESCRIPTION
Part of ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7677

- (azureSearch.js) Updates filter expression logic to no longer expect lastLogin to be a an integer, as the updated index structure no longer uses integers and uses DateTimes.
- (userSearchHelpers.js) Fixed translation of possible values from integers to DateTime information:
  - 0 is the equivalent of never, which in the new index is null instead of 0.
  - 1 is the equivalent of "not never", which in the new index is anything other than null.
  - All other values are converted into DateTime values instead of remaining as timestamps.